### PR TITLE
Add shift bitwise operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## 2.2.0 - 2025-06-07
+## 2.2.0 - 2025-06-05
 
 ### Added
 - Left (`<<`) and right (`>>`) shift operators.
 
-## 2.1.0 - 2025-06-06
+## 2.1.0 - 2025-06-05
 
 ### Added
 - Introduced `^` as the bitwise XOR operator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0 - 2025-06-07
+
+### Added
+- Left (`<<`) and right (`>>`) shift operators.
+
 ## 2.1.0 - 2025-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 | Capability | Details |
 |------------|---------|
-| Tokenisation | Splits input into `NumberToken`, `OperatorToken`, and `ParenToken` at the type level. Supported operators include arithmetic, bitwise (`&`, `|`, `^`), comparison, and ternary tokens. |
+| Tokenisation | Splits input into `NumberToken`, `OperatorToken`, and `ParenToken` at the type level. Supported operators include arithmetic, bitwise (`&`, `|`, `^`, `<<`, `>>`), comparison, and ternary tokens. |
 | Parser | Recursive-descent parser with correct precedence, associativity, parentheses, and unary ± support. Produces a canonical AST string. |
 | Evaluator | Delegates arithmetic to [`ts-arithmetic`](https://github.com/arielhs/ts-arithmetic) for arbitrary-precision math at the type level. |
 | Decimals & negatives | Works with decimal literals and unary operators out of the box. |
@@ -54,6 +54,8 @@ type E = TypeExpr<"5 | 2">;           // 7
 type F = TypeExpr<"3 > 2">;           // true
 type G = TypeExpr<"1 > 2 ? 8 : 9">;  // 9
 type H = TypeExpr<"5 ^ 2">;           // 7
+type I = TypeExpr<"1 << 3">;         // 8
+type J = TypeExpr<"8 >> 2">;         // 2
 ```
 
 These correspond to the reference tests in the source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gilkeyio/type-expression",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gilkeyio/type-expression",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "ts-arithmetic": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilkeyio/type-expression",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Compile-time type-level arithmetic expression evaluator for TypeScript",
   "types": "src/index.ts",
   "files": [

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -70,6 +70,13 @@ type BitwiseXor<A extends number, B extends number> = BitwiseOr<
     : never
   : never;
 
+type LeftShift<A extends number, B extends number> = Multiply<A, Pow<2, B>>;
+
+type RightShift<A extends number, B extends number> = Divide<
+  Subtract<A, Mod<A, Pow<2, B>>>,
+  Pow<2, B>
+>;
+
 /**
  * The *key* is to handle +(...) and -(...) with a single pattern each,
  * then decide whether it’s unary or binary based on SplitTopLevel.
@@ -93,6 +100,10 @@ export type Evaluate<S extends string> = S extends `n:${infer N extends number}`
   ? EvaluateMod<Body>
   : S extends `&(${infer Body})`
   ? EvaluateAnd<Body>
+  : S extends `<<(${infer Body})`
+  ? EvaluateLeftShift<Body>
+  : S extends `>>(${infer Body})`
+  ? EvaluateRightShift<Body>
   : S extends `^(${infer Body})`
   ? EvaluateXor<Body>
   : S extends `|(${infer Body})`
@@ -162,6 +173,20 @@ type EvaluateMod<S extends string> = SplitTopLevel<S> extends [infer L, infer R]
 
 type EvaluateAnd<S extends string> = SplitTopLevel<S> extends [infer L, infer R]
   ? BitwiseAnd<
+      Evaluate<Trim<Extract<L, string>>>,
+      Evaluate<Trim<Extract<R, string>>>
+    >
+  : never;
+
+type EvaluateLeftShift<S extends string> = SplitTopLevel<S> extends [infer L, infer R]
+  ? LeftShift<
+      Evaluate<Trim<Extract<L, string>>>,
+      Evaluate<Trim<Extract<R, string>>>
+    >
+  : never;
+
+type EvaluateRightShift<S extends string> = SplitTopLevel<S> extends [infer L, infer R]
+  ? RightShift<
       Evaluate<Trim<Extract<L, string>>>,
       Evaluate<Trim<Extract<R, string>>>
     >

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -10,6 +10,8 @@ type Operator =
   | "&"
   | "^"
   | "|"
+  | "<<"
+  | ">>"
   | "<"
   | "<="
   | ">"
@@ -89,11 +91,15 @@ type TokenizeOne<S extends string> = TrimLeft<S> extends ""
     ? [{ type: "paren"; value: C }, Rest]
     : // operators, including multi-character tokens
     C extends "<"
-    ? Rest extends `=${infer R2}`
+    ? Rest extends `<${infer R2}`
+      ? [{ type: "operator"; value: "<<" }, R2]
+      : Rest extends `=${infer R2}`
       ? [{ type: "operator"; value: "<=" }, R2]
       : [{ type: "operator"; value: "<" }, Rest]
     : C extends ">"
-    ? Rest extends `=${infer R2}`
+    ? Rest extends `>${infer R2}`
+      ? [{ type: "operator"; value: ">>" }, R2]
+      : Rest extends `=${infer R2}`
       ? [{ type: "operator"; value: ">=" }, R2]
       : [{ type: "operator"; value: ">" }, Rest]
     : C extends "="

--- a/tests/evaluate.test.ts
+++ b/tests/evaluate.test.ts
@@ -371,3 +371,15 @@ type EvalNestedTernary = Expect<
  * "^(n:5,n:2)" => 7
  */
 type EvalBitwiseXor = Expect<Equal<Evaluate<"^(n:5,n:2)">, 7>>;
+
+/**
+ * 53. Left shift
+ * "<<(n:1,n:3)" => 8
+ */
+type EvalLeftShift = Expect<Equal<Evaluate<"<<(n:1,n:3)">, 8>>;
+
+/**
+ * 54. Right shift
+ * ">>(n:8,n:2)" => 2
+ */
+type EvalRightShift = Expect<Equal<Evaluate<">>(n:8,n:2)">, 2>>;

--- a/tests/expression_string.test.ts
+++ b/tests/expression_string.test.ts
@@ -340,3 +340,15 @@ type ExprXorLeftAssoc = Expect<Equal<TypeExpr<"1 ^ 2 ^ 4">, 7>>
  * Explanation: 0b11111111 ^ 0b10101010 = 0b01010101 = 85
  */
 type ExprXorHigh = Expect<Equal<TypeExpr<"255 ^ 170">, 85>>
+
+/**
+ * 57. Left shift
+ * "1 << 3" => 8
+ */
+type ExprLeftShift = Expect<Equal<TypeExpr<"1 << 3">, 8>>
+
+/**
+ * 58. Right shift
+ * "8 >> 2" => 2
+ */
+type ExprRightShift = Expect<Equal<TypeExpr<"8 >> 2">, 2>>

--- a/tests/expression_string.test.ts
+++ b/tests/expression_string.test.ts
@@ -352,3 +352,65 @@ type ExprLeftShift = Expect<Equal<TypeExpr<"1 << 3">, 8>>
  * "8 >> 2" => 2
  */
 type ExprRightShift = Expect<Equal<TypeExpr<"8 >> 2">, 2>>
+
+/**
+ * 59. Left shift by zero
+ * "4 << 0" => 4
+ */
+type ExprLeftShiftZero = Expect<Equal<TypeExpr<"4 << 0">, 4>>
+
+/**
+ * 60. Right shift by zero
+ * "4 >> 0" => 4
+ */
+type ExprRightShiftZero = Expect<Equal<TypeExpr<"4 >> 0">, 4>>
+
+/**
+ * 61. Left shift a power of two
+ * "2 << 4" => 32
+ */
+type ExprLeftShiftPower = Expect<Equal<TypeExpr<"2 << 4">, 32>>
+
+/**
+ * 62. Right shift a power of two
+ * "64 >> 3" => 8
+ */
+type ExprRightShiftPower = Expect<Equal<TypeExpr<"64 >> 3">, 8>>
+
+/**
+ * 63. Left shift and right shift chain
+ * "1 << 4 >> 2" => (1 << 4) = 16, then 16 >> 2 = 4
+ */
+type ExprShiftChain = Expect<Equal<TypeExpr<"1 << 4 >> 2">, 4>>
+
+/**
+ * 64. Left shift with parentheses
+ * "1 << (1 << 1)" => 1 << 2 => 4
+ */
+type ExprLeftShiftNested = Expect<Equal<TypeExpr<"1 << (1 << 1)">, 4>>
+
+/**
+ * 65. Right shift with parentheses
+ * "32 >> (1 + 2)" => 32 >> 3 => 4
+ */
+type ExprRightShiftNested = Expect<Equal<TypeExpr<"32 >> (1 + 2)">, 4>>
+
+/**
+ * 66. Right shift a non-power-of-two number
+ * "19 >> 1" => 9
+ */
+type ExprRightShiftOdd = Expect<Equal<TypeExpr<"19 >> 1">, 9>>
+
+/**
+ * 67. Largest Left shift. (lower than 2 ^ 53 - 1)
+ * "1 << 52" => 4503599627370496
+ */
+type ExprLeftShiftMax = Expect<Equal<TypeExpr<"1 << 52">, 4503599627370496>>
+
+type blah = TypeExpr<"1 << 52">
+
+/**
+ * 68. Right shift to zero
+ * "1 >> 3" => 0
+ */
+type ExprRightShiftToZero = Expect<Equal<TypeExpr<"1 >> 3">, 0>>

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -325,3 +325,15 @@ type ParseNestedTernary = Expect<
  * "5 ^ 2" => "^(n:5,n:2)"
  */
 type ParseBitwiseXor = Expect<Equal<ToAstString<"5 ^ 2">, "^(n:5,n:2)">>;
+
+/**
+ * 50. Left shift
+ * "1 << 3" => "<<(n:1,n:3)"
+ */
+type ParseLeftShift = Expect<Equal<ToAstString<"1 << 3">, "<<(n:1,n:3)">>;
+
+/**
+ * 51. Right shift
+ * "8 >> 2" => ">>(n:8,n:2)"
+ */
+type ParseRightShift = Expect<Equal<ToAstString<"8 >> 2">, ">>(n:8,n:2)">>;

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -884,3 +884,41 @@ type TokenXor = Expect<
     ]
   >
 >;
+
+/**
+ * 44. Left shift
+ * "1 << 3" => [
+ *   { type: "number"; value: 1 },
+ *   { type: "operator"; value: "<<" },
+ *   { type: "number"; value: 3 }
+ * ]
+ */
+type TokenLeftShift = Expect<
+  Equal<
+    Tokenize<"1 << 3">,
+    [
+      { type: "number"; value: 1 },
+      { type: "operator"; value: "<<" },
+      { type: "number"; value: 3 }
+    ]
+  >
+>;
+
+/**
+ * 45. Right shift
+ * "8 >> 2" => [
+ *   { type: "number"; value: 8 },
+ *   { type: "operator"; value: ">>" },
+ *   { type: "number"; value: 2 }
+ * ]
+ */
+type TokenRightShift = Expect<
+  Equal<
+    Tokenize<"8 >> 2">,
+    [
+      { type: "number"; value: 8 },
+      { type: "operator"; value: ">>" },
+      { type: "number"; value: 2 }
+    ]
+  >
+>;


### PR DESCRIPTION
## Summary
- support `<<` and `>>` tokens
- parse and evaluate left/right shift operators
- document shift operators and bump version to 2.2.0
- test coverage for new operators

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68419d6724e88322b640f6edafb7cccf